### PR TITLE
Fixes APlayer Demo Page

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -43,7 +43,8 @@
             font-size: 18px;
         }
     </style>
-<script src="APlayer.js"></script>
+<script src="../dist/aplayer.min.js"></script>
+<link rel="stylesheet" type="text/css" href="../dist/aplayer.min.css">.
 </head>
 <body>
     <div class="container">


### PR DESCRIPTION
Fixes the APlayer demo page by adding links `aplayer.min.js` and `aplayer.min.css`

Currently the demo page is trying to use `APlayer.js` which doesn't exist in the demo folder. [Line 46](https://github.com/MoePlayer/APlayer/blob/master/demo/index.html#L46)