### PR TITLE
修复:中文文档API功能写错

### DIFF
--- a/docs/zh-Hans/README.md
+++ b/docs/zh-Hans/README.md
@@ -172,9 +172,9 @@ const ap = new APlayer({
   ap.notice('Amazing player', 2000, 0.8);
   ```
 
-+ `ap.skipBack()`: 切换到下一首音频
++ `ap.skipBack()`: 切换到上一首音频
 
-+ `ap.skipForward()`: 切换到上一首音频
++ `ap.skipForward()`: 切换到下一首音频
 
 + `ap.destroy()`: 销毁播放器
 


### PR DESCRIPTION
> 中文文档错误
- `ap.skipBack()`: 切换到下一首音频
- `ap.skipForward()`:切换到上一首音频

> 修复如下
- `ap.skipBack()`: 切换到上一首音频
- `ap.skipForward()`:切换到下一首音频