### PR TITLE
fix: 初始化进度时歌词未更新

### DIFF
--- a/src/js/lrc.js
+++ b/src/js/lrc.js
@@ -81,8 +81,8 @@ class Lrc {
         this.container.innerHTML = tplLrc({
             lyrics: this.parsed[index]
         });
-        this.update(0);
         this.current = this.parsed[index];
+        this.update(0);
     }
 
     /**


### PR DESCRIPTION
相关问题 #283

#### 说明
切换音乐调用`update`时，`this.current`歌词还未更新，依旧是上一首歌词。