### PR TITLE
修复loaded bar显示bug

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -151,6 +151,10 @@ class APlayer {
         });
 
         // show audio loaded bar: to inform interested parties of progress downloading the media
+        this.on('canplay', () => {
+            const percentage = this.audio.buffered.length ? this.audio.buffered.end(this.audio.buffered.length - 1) / this.duration : 0;
+            this.bar.set('loaded', percentage, 'width');
+        });
         this.on('progress', () => {
             const percentage = this.audio.buffered.length ? this.audio.buffered.end(this.audio.buffered.length - 1) / this.duration : 0;
             this.bar.set('loaded', percentage, 'width');


### PR DESCRIPTION
修复了在网络环境较差的情况下资源第一次触发progress事件时TimeRanges的长度为0，导致loaded bar显示有误的bug