### PR TITLE
吸底模式下如果页面滚动到末尾，歌词全透明处理。

### DIFF
--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -20,7 +20,7 @@ $aplayer-height-lrc: $aplayer-height + $lrc-height - 6;
     svg {
         width: 100%;
         height: 100%;
-        
+
         path,
         circle {
             fill: #fff;
@@ -59,7 +59,7 @@ $aplayer-height-lrc: $aplayer-height + $lrc-height - 6;
 
     &.aplayer-narrow {
         width: $aplayer-height;
-        
+
         .aplayer-info {
             display: none;
         }
@@ -113,6 +113,7 @@ $aplayer-height-lrc: $aplayer-height + $lrc-height - 6;
             z-index: 98;
             pointer-events: none;
             text-shadow: -1px -1px 0 #fff;
+            transition: opacity 0.5s;
 
             &:before,
             &:after {
@@ -218,7 +219,7 @@ $aplayer-height-lrc: $aplayer-height + $lrc-height - 6;
         background-color: transparent;
         outline: none;
         cursor: pointer;
-        opacity: .8;
+        opacity: 0.8;
         vertical-align: middle;
         padding: 0;
         font-size: 12px;
@@ -226,7 +227,7 @@ $aplayer-height-lrc: $aplayer-height + $lrc-height - 6;
         display: inline-block;
 
         path {
-            transition: all .2s ease-in-out;
+            transition: all 0.2s ease-in-out;
         }
     }
 
@@ -391,7 +392,7 @@ $aplayer-height-lrc: $aplayer-height + $lrc-height - 6;
                             width: 10px;
                             border-radius: 50%;
                             cursor: pointer;
-                            transition: all .3s ease-in-out;
+                            transition: all 0.3s ease-in-out;
                             transform: scale(0);
                         }
                     }
@@ -463,7 +464,7 @@ $aplayer-height-lrc: $aplayer-height + $lrc-height - 6;
                     height: 0;
                     z-index: 99;
                     overflow: hidden;
-                    transition: all .2s ease-in-out;
+                    transition: all 0.2s ease-in-out;
 
                     &.aplayer-volume-bar-wrap-active {
                         height: 40px;
@@ -518,9 +519,9 @@ $aplayer-height-lrc: $aplayer-height + $lrc-height - 6;
             width: 100%;
             height: 10%;
             content: ' ';
-            background: -moz-linear-gradient(top, rgba(255,255,255,1) 0%, rgba(255,255,255,0) 100%);
-            background: -webkit-linear-gradient(top, rgba(255,255,255,1) 0%,rgba(255,255,255,0) 100%);
-            background: linear-gradient(to bottom, rgba(255,255,255,1) 0%,rgba(255,255,255,0) 100%);
+            background: -moz-linear-gradient(top, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 0) 100%);
+            background: -webkit-linear-gradient(top, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 0) 100%);
+            background: linear-gradient(to bottom, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 0) 100%);
             filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='#00ffffff',GradientType=0 );
         }
 
@@ -533,9 +534,9 @@ $aplayer-height-lrc: $aplayer-height + $lrc-height - 6;
             width: 100%;
             height: 33%;
             content: ' ';
-            background: -moz-linear-gradient(top, rgba(255,255,255,0) 0%, rgba(255,255,255,0.8) 100%);
-            background: -webkit-linear-gradient(top, rgba(255,255,255,0) 0%,rgba(255,255,255,0.8) 100%);
-            background: linear-gradient(to bottom, rgba(255,255,255,0) 0%,rgba(255,255,255,0.8) 100%);
+            background: -moz-linear-gradient(top, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.8) 100%);
+            background: -webkit-linear-gradient(top, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.8) 100%);
+            background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.8) 100%);
             filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', endColorstr='#ccffffff',GradientType=0 );
         }
 
@@ -653,7 +654,7 @@ $aplayer-height-lrc: $aplayer-height + $lrc-height - 6;
         font-size: 12px;
         border-radius: 4px;
         padding: 5px 10px;
-        transition: all .3s ease-in-out;
+        transition: all 0.3s ease-in-out;
         overflow: hidden;
         color: #fff;
         pointer-events: none;
@@ -692,15 +693,19 @@ $aplayer-height-lrc: $aplayer-height + $lrc-height - 6;
 }
 
 @keyframes aplayer-roll {
-    0%{left:0}
-    100%{left: -100%}
+    0% {
+        left: 0;
+    }
+    100% {
+        left: -100%;
+    }
 }
 
 @keyframes rotate {
     0% {
-        transform: rotate(0)
+        transform: rotate(0);
     }
     100% {
-        transform: rotate(360deg)
+        transform: rotate(360deg);
     }
 }

--- a/src/js/lrc.js
+++ b/src/js/lrc.js
@@ -29,7 +29,7 @@ class Lrc {
     }
 
     update(currentTime = this.player.audio.currentTime) {
-        if (this.index > this.current.length - 1 || currentTime < this.current[this.index][0] || (!this.current[this.index + 1] || currentTime >= this.current[this.index + 1][0])) {
+        if (this.index > this.current.length - 1 || currentTime < this.current[this.index][0] || !this.current[this.index + 1] || currentTime >= this.current[this.index + 1][0]) {
             for (let i = 0; i < this.current.length; i++) {
                 if (currentTime >= this.current[i][0] && (!this.current[i + 1] || currentTime < this.current[i + 1][0])) {
                     this.index = i;

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -64,6 +64,21 @@ class APlayer {
         if (this.options.fixed) {
             this.container.classList.add('aplayer-fixed');
             this.template.body.style.width = this.template.body.offsetWidth - 18 + 'px';
+
+            document.addEventListener(
+                'scroll',
+                // 防抖优化
+                utils.debounce(() => {
+                    const inHeight = window.innerHeight,
+                        bottom = document.body.getBoundingClientRect().bottom;
+                    const isBottom = bottom - inHeight <= 30;
+                    if (isBottom) {
+                        this.container.querySelector('.aplayer.aplayer-fixed .aplayer-lrc').style = 'opacity: 0';
+                    } else {
+                        this.container.querySelector('.aplayer.aplayer-fixed .aplayer-lrc').style = '';
+                    }
+                }, 50)
+            );
         }
         if (this.options.mini) {
             this.setMode('mini');

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -50,6 +50,16 @@ const utils = {
             })
         );
     },
+
+    debounce: (fn, wait) => {
+        let timeout = null;
+        return function() {
+            if (timeout !== null) {
+                clearTimeout(timeout);
+            }
+            timeout = setTimeout(fn, wait);
+        };
+    },
 };
 
 export default utils;


### PR DESCRIPTION
在吸底模式下，页面滚动到末尾，歌词会遮住footer中的文字。所以我想着是不是应该需要加一个监听器，判断如果滚动到底就透明处理。使用了防抖函数，优化了监听器的性能。

尝试了一下，效果还行。

![](https://raw.githubusercontent.com/Innei/img-bed/master/20191209221649.gif)