### PR TITLE
fix: 最后一句歌词频繁更新的问题

### DIFF
--- a/src/js/lrc.js
+++ b/src/js/lrc.js
@@ -31,7 +31,7 @@ class Lrc {
     update(currentTime = this.player.audio.currentTime) {
         if (this.index > this.current.length - 1 || currentTime < this.current[this.index][0] || (!this.current[this.index + 1] || currentTime >= this.current[this.index + 1][0])) {
             for (let i = 0; i < this.current.length; i++) {
-                if (currentTime >= this.current[i][0] && (!this.current[i + 1] || currentTime < this.current[i + 1][0])) {
+                if (currentTime >= this.current[i][0] && (!this.current[i + 1] || currentTime < this.current[i + 1][0]) && i !== this.index) {
                     this.index = i;
                     this.container.style.transform = `translateY(${-this.index * 16}px)`;
                     this.container.style.webkitTransform = `translateY(${-this.index * 16}px)`;


### PR DESCRIPTION
当歌词显示到最后时，会出现频繁更新 DOM 的问题，这里简单加一个条件以避免这个问题

https://github.com/MoePlayer/APlayer/blob/b9582f9ddc7d4865150b1d9edc82547159a317f7/src/js/lrc.js#L33-L41

![preview](https://i.loli.net/2020/10/05/mnGMOfk2strj3YZ.jpg)